### PR TITLE
Add recruiter-optimized portfolio enhancements

### DIFF
--- a/src/components/company-logos.tsx
+++ b/src/components/company-logos.tsx
@@ -13,7 +13,7 @@ export function RelayLogo(props: LogoProps) {
 export function HomebaseLogo(props: LogoProps) {
   return (
     <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
-      <path d="M12 3L4 9v12h5v-7h6v7h5V9l-8-6zm0 2.5l6 4.5v9h-2v-7H8v7H6v-9l6-4.5z" />
+      <path d="M4 3h5v8h6V3h5v18h-5v-8H9v8H4V3z" />
     </svg>
   );
 }
@@ -21,7 +21,7 @@ export function HomebaseLogo(props: LogoProps) {
 export function WealthsimpleLogo(props: LogoProps) {
   return (
     <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
-      <path d="M2 7h3.5l2.5 8.5L11 7h2l3 8.5L18.5 7H22l-5 14h-3l-3-8.5L8 21H5L2 7z" />
+      <path d="M1 4h3.5l2.5 9 3-9h4l3 9 2.5-9H23l-5 16h-3.5l-2.5-8-2.5 8H6L1 4z" />
     </svg>
   );
 }

--- a/src/components/experience-list.tsx
+++ b/src/components/experience-list.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { experience } from "@/data/experience";
 import { ExperienceModal } from "./experience-modal";
+import { companyLogos } from "./company-logos";
 
 export function ExperienceList() {
   const [selected, setSelected] = useState<(typeof experience)[number] | null>(
@@ -20,29 +21,86 @@ export function ExperienceList() {
         </span>
       </div>
 
-      <div className="flex flex-col gap-16">
-        {experience.map((job, i) => (
-          <article
-            key={job.company}
-            onClick={() => setSelected(job)}
-            className="grid grid-cols-[auto_1fr_auto] gap-8 items-baseline py-4 cursor-pointer transition-opacity hover:opacity-60"
-          >
-            <span className="font-mono text-[0.7rem] text-text-tertiary pt-1">
-              {String(i + 1).padStart(2, "0")}
-            </span>
-            <div className="flex flex-col gap-2">
-              <h3 className="font-serif text-[clamp(1.5rem,4vw,2.5rem)] font-normal tracking-tight leading-none">
-                {job.company}
-              </h3>
-              <p className="font-mono text-[0.75rem] text-text-secondary tracking-wide mb-1">
-                {job.role}
-              </p>
-            </div>
-            <span className="font-mono text-[0.7rem] text-text-tertiary self-start pt-2">
-              {job.years}
-            </span>
-          </article>
-        ))}
+      <div className="relative">
+        {/* Timeline line - desktop only */}
+        <div className="absolute left-[0.45rem] top-6 bottom-6 w-px bg-border hidden md:block" />
+
+        <div className="flex flex-col gap-12 md:gap-8">
+          {experience.map((job, i) => {
+            const Logo = companyLogos[job.logo];
+            const isLast = i === experience.length - 1;
+
+            return (
+              <article
+                key={job.company}
+                onClick={() => setSelected(job)}
+                className={`
+                  relative grid grid-cols-[1fr_auto] md:grid-cols-[auto_1fr_auto] gap-4 md:gap-8
+                  py-5 px-0 md:pl-8 cursor-pointer rounded-sm
+                  transition-all duration-300 ease-out
+                  hover:bg-bg-subtle/50 hover:shadow-sm hover:scale-[1.005]
+                  ${job.current ? "border-l-2 border-accent pl-4 md:pl-8 md:border-l-0 md:ml-0" : ""}
+                `}
+              >
+                {/* Timeline dot - desktop only */}
+                <div
+                  className={`
+                    absolute left-0 top-7 w-[0.6rem] h-[0.6rem] rounded-full border-2 border-background
+                    hidden md:block transition-colors
+                    ${job.current ? "bg-accent animate-pulse-dot" : "bg-border"}
+                    ${isLast ? "opacity-50" : ""}
+                  `}
+                />
+
+                {/* Index number - desktop only */}
+                <span className="font-mono text-[0.7rem] text-text-tertiary pt-1.5 hidden md:block">
+                  {String(i + 1).padStart(2, "0")}
+                </span>
+
+                <div className="flex flex-col gap-2">
+                  {/* Company name with logo */}
+                  <div className="flex items-center gap-3">
+                    <div className="w-5 h-5 text-text-tertiary opacity-60 group-hover:opacity-100 transition-opacity flex-shrink-0">
+                      <Logo className="w-full h-full" />
+                    </div>
+                    <h3 className="font-serif text-[clamp(1.5rem,4vw,2.5rem)] font-normal tracking-tight leading-none">
+                      {job.company}
+                    </h3>
+                    {job.current && (
+                      <span className="font-mono text-[0.6rem] uppercase tracking-wider text-accent bg-accent/10 px-2 py-0.5 rounded-sm">
+                        Now
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Role */}
+                  <p className="font-mono text-[0.75rem] text-text-secondary tracking-wide">
+                    {job.role}
+                  </p>
+
+                  {/* Highlights/metrics */}
+                  {job.highlights && job.highlights.length > 0 && (
+                    <div className="flex flex-wrap gap-2 mt-1">
+                      {job.highlights.map((highlight) => (
+                        <span
+                          key={highlight}
+                          className="font-mono text-[0.65rem] text-accent tracking-wide bg-accent/8 px-2 py-0.5 rounded-sm"
+                        >
+                          {highlight}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Years */}
+                <span className="font-mono text-[0.7rem] text-text-tertiary self-start pt-2">
+                  {job.years}
+                </span>
+              </article>
+            );
+          })}
+        </div>
       </div>
 
       <ExperienceModal

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,11 +1,42 @@
 export function Footer() {
   return (
-    <footer className="py-16 flex justify-between items-center font-mono text-[0.7rem] text-text-tertiary tracking-wide">
-      <div className="flex items-center gap-2">
-        <span className="w-1.5 h-1.5 bg-accent rounded-full animate-pulse-dot" />
-        <span>Available for interesting problems</span>
+    <footer className="py-16 border-t border-border">
+      <div className="flex flex-col sm:flex-row justify-between gap-8 font-mono text-[0.7rem] text-text-tertiary tracking-wide">
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <span className="w-1.5 h-1.5 bg-accent rounded-full animate-pulse-dot" />
+            <span>Available for interesting problems</span>
+          </div>
+          <p className="text-[0.65rem] max-w-[280px] leading-relaxed opacity-70">
+            Open to advisory roles, consulting on lifecycle strategy, and select
+            fractional engagements.
+          </p>
+        </div>
+
+        <div className="flex flex-col sm:items-end gap-4">
+          <div className="flex gap-6">
+            <a
+              href="mailto:alvin@alvindang.com"
+              className="transition-colors hover:text-accent"
+            >
+              Email
+            </a>
+            <a
+              href="https://linkedin.com/in/alvindang"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="transition-colors hover:text-accent"
+            >
+              LinkedIn
+            </a>
+          </div>
+          <div className="flex items-center gap-2 text-[0.65rem] opacity-70">
+            <span>Toronto, Canada</span>
+            <span>·</span>
+            <span>&copy; {new Date().getFullYear()}</span>
+          </div>
+        </div>
       </div>
-      <span>&copy; {new Date().getFullYear()}</span>
     </footer>
   );
 }

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -9,10 +9,17 @@ export function Hero() {
           Lifecycle marketing leader. I build playbooks for scaling things that
           matter.
         </p>
-        <div className="font-mono text-[0.8rem] text-text-tertiary leading-loose pt-1">
-          <span className="block text-text-secondary">Currently at Relay</span>
-          <span className="block">Previously Wealthsimple, Shopify</span>
-          <span className="block">Lifecycle · Growth · Systems</span>
+        <div className="font-mono text-[0.8rem] leading-loose pt-1 space-y-3">
+          <div className="flex items-center gap-2">
+            <span className="w-1.5 h-1.5 bg-accent rounded-full animate-pulse-dot" />
+            <span className="text-text-secondary">Currently at Relay</span>
+          </div>
+          <div className="text-text-tertiary pl-3.5 border-l border-border/50">
+            <span className="block">Previously Wealthsimple, Shopify</span>
+            <span className="block mt-2 pt-2 border-t border-border/30">
+              Lifecycle · Growth · Systems
+            </span>
+          </div>
         </div>
       </div>
       <div className="absolute bottom-16 right-8 font-mono text-[0.7rem] text-text-tertiary tracking-widest uppercase [writing-mode:vertical-rl] animate-fade-up [animation-delay:0.6s]">

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -11,31 +11,53 @@ const navItems = [
 
 export function Nav() {
   const [isVisible, setIsVisible] = useState(true);
+  const [activeSection, setActiveSection] = useState<string>("");
 
   useEffect(() => {
-    let observer: IntersectionObserver | null = null;
+    let footerObserver: IntersectionObserver | null = null;
+    let sectionObserver: IntersectionObserver | null = null;
 
-    const setupObserver = () => {
+    const setupObservers = () => {
       const footer = document.querySelector("footer");
-      if (!footer) return false;
+      const sections = navItems
+        .map((item) => document.querySelector(item.href))
+        .filter(Boolean) as Element[];
 
-      observer = new IntersectionObserver(
+      if (!footer || sections.length === 0) return false;
+
+      footerObserver = new IntersectionObserver(
         ([entry]) => {
           setIsVisible(!entry.isIntersecting);
         },
         { threshold: 0, rootMargin: "100px" }
       );
 
-      observer.observe(footer);
+      sectionObserver = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              setActiveSection(`#${entry.target.id}`);
+            }
+          });
+        },
+        { threshold: 0.3, rootMargin: "-20% 0px -60% 0px" }
+      );
+
+      footerObserver.observe(footer);
+      sections.forEach((section) => sectionObserver?.observe(section));
+
       return true;
     };
 
-    if (!setupObserver()) {
-      const retryId = requestAnimationFrame(setupObserver);
+    if (!setupObservers()) {
+      const retryId = requestAnimationFrame(setupObservers);
       return () => cancelAnimationFrame(retryId);
     }
 
-    return () => observer?.disconnect();
+    return () => {
+      footerObserver?.disconnect();
+      sectionObserver?.disconnect();
+    };
   }, []);
 
   return (
@@ -47,15 +69,26 @@ export function Nav() {
         ${isVisible ? "opacity-100" : "opacity-0 pointer-events-none"}
       `}
     >
-      {navItems.map((item) => (
-        <a
-          key={item.href}
-          href={item.href}
-          className="text-text-tertiary hover:text-accent transition-colors"
-        >
-          <span className="text-text-tertiary/60">{item.index}</span> {item.label}
-        </a>
-      ))}
+      {navItems.map((item) => {
+        const isActive = activeSection === item.href;
+        return (
+          <a
+            key={item.href}
+            href={item.href}
+            className={`
+              transition-all duration-200
+              ${isActive ? "text-accent translate-x-1" : "text-text-tertiary hover:text-accent"}
+            `}
+          >
+            <span
+              className={`transition-colors ${isActive ? "text-accent/80" : "text-text-tertiary/60"}`}
+            >
+              {item.index}
+            </span>{" "}
+            {item.label}
+          </a>
+        );
+      })}
     </nav>
   );
 }
@@ -69,7 +102,8 @@ export function MobileNav() {
           href={item.href}
           className="text-text-tertiary hover:text-accent transition-colors"
         >
-          <span className="text-text-tertiary/60">{item.index}</span> {item.label}
+          <span className="text-text-tertiary/60">{item.index}</span>{" "}
+          {item.label}
         </a>
       ))}
     </nav>

--- a/src/components/projects-list.tsx
+++ b/src/components/projects-list.tsx
@@ -1,6 +1,8 @@
 import { projects, type Project } from "@/data/projects";
 
 export function ProjectsList() {
+  const hasRealProjects = projects.some((p) => p.url !== "#");
+
   return (
     <section id="projects" className="py-32 border-t border-border">
       <div className="flex justify-between items-baseline mb-16">
@@ -8,16 +10,42 @@ export function ProjectsList() {
           Projects
         </h2>
         <span className="font-mono text-[0.7rem] text-text-tertiary">
-          {String(projects.length).padStart(2, "0")}
+          {hasRealProjects ? String(projects.length).padStart(2, "0") : "—"}
         </span>
       </div>
 
-      <div className="flex flex-col gap-16">
-        {projects.map((project, i) => (
-          <ProjectCard key={project.title} project={project} index={i} />
-        ))}
-      </div>
+      {hasRealProjects ? (
+        <div className="flex flex-col gap-16">
+          {projects.map((project, i) => (
+            <ProjectCard key={project.title} project={project} index={i} />
+          ))}
+        </div>
+      ) : (
+        <PlaceholderCard />
+      )}
     </section>
+  );
+}
+
+function PlaceholderCard() {
+  return (
+    <div className="relative border border-dashed border-border/60 p-8 md:p-12">
+      <div className="flex flex-col gap-4">
+        <span className="font-mono text-[0.7rem] tracking-widest uppercase text-text-tertiary">
+          In Development
+        </span>
+        <h3 className="font-serif text-[clamp(1.5rem,4vw,2.5rem)] font-light tracking-tight leading-tight text-text-secondary/70">
+          Side projects launching 2025
+        </h3>
+        <p className="font-mono text-[0.8rem] text-text-tertiary max-w-[400px] leading-relaxed">
+          Currently building tools at the intersection of lifecycle marketing
+          and product growth. Check back soon.
+        </p>
+      </div>
+      <div className="absolute top-4 right-4 font-mono text-[0.65rem] text-text-tertiary/50">
+        01
+      </div>
+    </div>
   );
 }
 

--- a/src/components/writing-list.tsx
+++ b/src/components/writing-list.tsx
@@ -8,12 +8,12 @@ export function WritingList() {
           Writing
         </h2>
         <span className="font-mono text-[0.7rem] text-text-tertiary">
-          {String(posts.length).padStart(2, "0")}
+          {posts.length > 0 ? String(posts.length).padStart(2, "0") : "—"}
         </span>
       </div>
 
       {posts.length === 0 ? (
-        <p className="font-mono text-[0.8rem] text-text-tertiary">Coming soon.</p>
+        <WritingPlaceholder />
       ) : (
         <div className="flex flex-col gap-8">
           {posts.map((post) => (
@@ -33,5 +33,18 @@ export function WritingList() {
         </div>
       )}
     </section>
+  );
+}
+
+function WritingPlaceholder() {
+  return (
+    <div className="border-l-2 border-border pl-6 py-2">
+      <p className="font-serif text-lg italic text-text-secondary/70 mb-3">
+        Essays on lifecycle marketing, growth systems, and building at scale.
+      </p>
+      <p className="font-mono text-[0.75rem] text-text-tertiary">
+        Newsletter launching soon
+      </p>
+    </div>
   );
 }

--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -5,6 +5,8 @@ export interface Experience {
   description: string;
   url: string;
   logo: "relay" | "homebase" | "wealthsimple" | "shopify" | "blackberry";
+  current?: boolean;
+  highlights?: string[];
 }
 
 export const experience: Experience[] = [
@@ -12,41 +14,49 @@ export const experience: Experience[] = [
     company: "Relay",
     role: "Director, Lifecycle Marketing",
     years: "2024–Present",
-    description: "Building growth systems for SMB fintech. Leading lifecycle strategy across onboarding, activation, and retention.",
+    description:
+      "Building growth systems for SMB fintech. Leading lifecycle strategy across onboarding, activation, and retention.",
     url: "https://relayfi.com",
     logo: "relay",
+    current: true,
   },
   {
     company: "Homebase",
     role: "Director, Lifecycle Marketing",
     years: "2022–2024",
-    description: "Built Lifecycle and Top-of-Funnel functions from scratch. Helped secure $60M Series D through growth initiatives.",
+    description:
+      "Built Lifecycle and Top-of-Funnel functions from scratch. Helped secure $60M Series D through growth initiatives.",
     url: "https://joinhomebase.com",
     logo: "homebase",
+    highlights: ["$60M Series D"],
   },
   {
     company: "Wealthsimple",
     role: "Head of Lifecycle → Growth PM",
     years: "2018–2022",
-    description: "Scaled team from 1 to 15. Built TLDR newsletter, grew to 2B messages/year. Drove growth from $350M to $5B AUM.",
+    description:
+      "Scaled team from 1 to 15. Built TLDR newsletter, grew to 2B messages/year. Drove growth from $350M to $5B AUM.",
     url: "https://wealthsimple.com",
     logo: "wealthsimple",
+    highlights: ["1→15 team", "2B msgs/yr", "$5B AUM"],
   },
   {
     company: "Shopify",
     role: "Marketing Automation Specialist",
     years: "2016–2018",
-    description: "Global lifecycle programs for Shopify Core, Capital, and Shipping. Post-IPO growth phase.",
+    description:
+      "Global lifecycle programs for Shopify Core, Capital, and Shipping. Post-IPO growth phase.",
     url: "https://shopify.com",
     logo: "shopify",
+    highlights: ["Post-IPO"],
   },
   {
     company: "BlackBerry",
     role: "Marketing Specialist, CRM",
     years: "2013–2014",
-    description: "BB10 Global Welcome program. Early career foundation in CRM and lifecycle marketing.",
+    description:
+      "BB10 Global Welcome program. Early career foundation in CRM and lifecycle marketing.",
     url: "https://blackberry.com",
     logo: "blackberry",
   },
 ];
-


### PR DESCRIPTION
## Summary
- Add pull-out impact metrics badges to experience entries (e.g., "$5B AUM growth", "2B messages/year")
- Add visual timeline connecting experience entries with accent dot for current role
- Implement scroll spy navigation highlighting active section
- Add company logo pills next to experience entries
- Enhance hero credentials with visual hierarchy and styling
- Expand footer with availability context and social links
- Refine "Coming Soon" placeholder states for Projects and Writing
- Fix Homebase and Wealthsimple SVG logos

## Test plan
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Desktop layout verified
- [x] Dark mode and light mode verified
- [x] Timeline and scroll spy work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)